### PR TITLE
カリキュラム08−3の変更

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Support\Facades\DB;
 use App\Post;
 use Illuminate\Http\Request;
 
@@ -10,12 +11,24 @@ class PostController extends Controller
     public function index(Post $post)
     //Postメソッドを使用するためにPostをかく
     {
+        $posts = DB::table('posts')->get();
         // return view('posts/index')->with(['posts' => $post->get()]);
         
         // return view('posts/index')->with(['posts' => $post->getByLimit()]);
         
-        return view('posts/index')->with(['posts' => $post->getPaginateByLimit()]);
+        return view('posts/index', ['posts' => $posts])->with(['posts' => $post->getPaginateByLimit()]);//with(['posts'~ のpostsはindex.blade.phpの$postsと連携している。
     }
+    
+    // public function show(Post $post) {
+    //     return view('posts/show')->with('posts' => $post);
+    // }
+    
+    public function show(Post $post)
+    {
+        return view('posts/show')->with(['post' => $post]);//ここで$post->get()としてしまうとせっかく$postで撮ったidの意味がなくなる
+    }
+    
+    
 }
 ?>
 

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -11,7 +11,7 @@
         <div class='posts'>
             @foreach ($posts as $post)
             <div class='post'>
-                <h2 class='title'>{{ $post->title }}</h2>
+                <h2 class='title'><a href="/posts/{{ $post->id }}">{{ $post->title }}</a></h2>
                 <p class='body'>{{ $post->body }}</p>
             </div>
             @endforeach

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,0 +1,26 @@
+
+<!DOCTYPE HTML>
+<html lang="{{ str_replace("_", "-", app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Posts</title>
+        <!-- Fonts -->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+        <link rel="stylesheet" href="/css/app.css">
+    </head>
+    <body>
+        <h1 class="title">
+            {{ $post->title }}
+        </h1>
+        <div class="content">
+            <div class="content__post">
+                <h3>本文</h3>
+                <p>{{ $post->body }}</p>    
+            </div>
+        </div>
+        <div class="footer">
+            <a href="/posts">戻る</a>
+        </div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,3 +12,5 @@
 */
 
 Route::get('/posts', 'PostController@index');
+
+Route::get('/posts/{post}', 'PostController@show');


### PR DESCRIPTION
- PostControllerにブログ投稿詳細画面表示用のshow関数を追加
- show関数で対象のPostsテーブルデータを取得し、show.blade.phpに引き継ぎ。
- show.blade.phpにて引き継いだデータを適切に表示
- https://〜〜〜/posts/(対象データID)のURLでGETリクエストのアクセスが来たら、PostControllerのshow関数が実行されるルーティング定義の追加
- 戻るリンクを押下するとブログ投稿一覧画面表示のリクエストを実行。
- 投稿タイトルをリンクに変更し、押下すると対象のブログ投稿の詳細画面に遷移する。